### PR TITLE
System menu toggle

### DIFF
--- a/src/items/menu.js
+++ b/src/items/menu.js
@@ -138,7 +138,8 @@ export default class MenuPanelItem extends PanelItem {
           } else if (action === 'logOut') {
             logout(false);
           }
-        }
+        },
+        toggle: true
       });
     };
 


### PR DESCRIPTION
Seems reasonable that clicking the Menu (top left) opens the system menu, then another click closes it. Currently the second click does nothing (in fact it closes and opens the menu, but this is not observable).

This suggestion depends on a second fix to @osjs/gui.